### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Digest.pm
+++ b/lib/Digest.pm
@@ -1,4 +1,4 @@
-module Digest;
+unit module Digest;
 
 sub prefix:<¬>(\x)       {   (+^ x) % 2**32 }
 sub infix:<⊞>(\x, \y)    {  (x + y) % 2**32 }

--- a/lib/Digest/RIPEMD.pm
+++ b/lib/Digest/RIPEMD.pm
@@ -1,4 +1,4 @@
-module Digest::RIPEMD;
+unit module Digest::RIPEMD;
 
 =begin CREDITS
 Crypto-JS v2.0.0

--- a/lib/Digest/SHA.pm
+++ b/lib/Digest/SHA.pm
@@ -1,4 +1,4 @@
-module Digest::SHA;
+unit module Digest::SHA;
 
 =begin Credits
 The code for SHA-1 comes from Rosetta code:


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.