### PR TITLE
Don't use explosive encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 This is a perl6 module implementing some digest algorithms in pure Perl6 (no parrot or nqp:: code).
 
 The interface is minimal: functions only return Blob and only take a Blob as
-argument.  It's up to the user to turn it into an hex string if he needs to.
+argument.  It's up to the user to turn it into an hex string if they need to.
 
     use Digest::SHA;
-    say my $sha256 = sha256 "hello".encode: 'ascii';
+    say my $sha256 = sha256 "hello".encode: 'utf8-c8';
     
     use Digest::RIPEMD;
-    say rmd160 "bye".encode: "ascii";
+    say rmd160 "bye".encode: 'utf8-c8';
 
     sub buf_to_hex { [~] $^buf.list».fmt: "%02x" }
     say buf_to_hex $sha256;


### PR DESCRIPTION
Encoding to ASCII will explode for codepoints >127.
Use utf8-c8 in example that'll accept anything.

(also; gender-neutralize the doc)